### PR TITLE
fix a bug in reading an empty vector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ cmake_minimum_required(VERSION 3.5.1)
 
 project(yaml_cpp_catkin)
 
-# required to use std::shared_ptr in code
 # required to use std::shared_ptr in code and to link the python bindings
 if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--no-as-needed")

--- a/include/yaml_cpp_catkin/yaml_cpp_fwd.hpp
+++ b/include/yaml_cpp_catkin/yaml_cpp_fwd.hpp
@@ -1,0 +1,13 @@
+/**
+ * @file yaml_cpp_fwd.hpp
+ * @author Maximilien Naveau (maximilien.naveau@gmail.com)
+ * @license License BSD-3-Clause
+ * @copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
+ * @date 2019-09-30
+ */
+
+#pragma once
+
+#include <yaml-cpp/yaml.h>
+#include "yaml_cpp_catkin/yaml_eigen.h"
+#include "yaml_cpp_catkin/yaml_tools.hpp"

--- a/include/yaml_cpp_catkin/yaml_eigen.h
+++ b/include/yaml_cpp_catkin/yaml_eigen.h
@@ -122,12 +122,19 @@ struct convert<Eigen::Matrix<Scalar,  Rows,  Cols,  Align,  RowsAtCompileTime,  
   static bool decode(const Node& node, Eigen_Type_& rhs){
     if(!node.IsSequence())
       return false;
-    else if(!node[0].IsSequence())
-      return decode_1d(node, rhs);
+    if(node.size() > 0)
+    {
+      if(!node[0].IsSequence())
+        return decode_1d(node, rhs);
+      else
+        return decode_2d(node, rhs);
+    }
     else
-      return decode_2d(node, rhs);
+    {
+      Converter_::resize_if_needed(0, 0, rhs);
+      return true;
+    }    
   }
-
 };
 
 

--- a/include/yaml_cpp_catkin/yaml_tools.hpp
+++ b/include/yaml_cpp_catkin/yaml_tools.hpp
@@ -1,0 +1,42 @@
+/**
+ * @file yaml_cpp.hpp
+ * @author Maximilien Naveau (maximilien.naveau@gmail.com)
+ * @license License BSD-3-Clause
+ * @copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
+ * @date 2019-09-30
+ */
+
+#pragma once
+
+#include <yaml-cpp/yaml.h>
+
+namespace YAML {
+
+  /**
+   * @brief helper function to safely read a yaml parameter
+   * 
+   * @tparam YamlType 
+   * @param node 
+   * @param name 
+   * @return YamlType 
+   */
+  template <typename YamlType>
+  static YamlType read_parameter(const YAML::Node& node, const std::string& name) {
+    try { return node[name.c_str()].as<YamlType>(); }
+    catch (...) { throw std::runtime_error("Error reading the yaml parameter [" + name + "]"); }
+  }
+
+  /**
+   * @brief helper function to safely read a yaml parameter
+   * 
+   * @tparam YamlType 
+   * @param node 
+   * @param name 
+   * @param parameter 
+   */
+  template <typename YamlType>
+  static void read_parameter(const YAML::Node& node, const std::string& name, YamlType& parameter) {
+    parameter = read_parameter<YamlType>(node, name);
+  }
+
+}


### PR DESCRIPTION
# What has changed

# has been added
 - modified the eigen parsing to be able to parse empty vectors/matrices
- add a forward declaration header
- add a `read_parameter` method with debug information in a std exception